### PR TITLE
no need to cast the orderid to a smaller size

### DIFF
--- a/CSIT5210 Assignment.ipynb
+++ b/CSIT5210 Assignment.ipynb
@@ -555,7 +555,7 @@
     "\n",
     "#  Task 1.4.1  Check the memory you have spent by the API .info()\n",
     "\n",
-    "#  Task 1.4.2  Compress the field orderid userid bikeid using a smaller data type int32 and the field biketype using int8\n",
+    "#  Task 1.4.2  Compress the field userid bikeid using a smaller data type int32 / uint32 and the field biketype using int8\n",
     "\n",
     "# Task 1.343 Check the memory you have spent again\n",
     "\n",


### PR DESCRIPTION
there is a discussion on casting the index to some another value like int32 is non-trivial. It is understood that using a type other than RangeInt may result in a slower computation as suggested in one of the comment.
 
https://stackoverflow.com/questions/44090944/how-to-change-index-dtype-of-pandas-dataframe-to-int32
 
Perhaps we may leave it as that.